### PR TITLE
nms compile; h5py requirement; widerface directory structure tree; simple progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Besides the superority on pedestrian detection demonstrated in the paper, we tak
 ```
   pip install -r requirements.txt
 ```
+3. Compile the nms module.
+```
+  cd $CSP/keras_csp
+  make
+```
 
 ### Preparation
 1. Download the dataset.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,20 @@ To reproduce the results in our paper, we have provided the models trained from 
 ### Extension--Face Detection
 1. Data preparation 
 
- You should firstly download the [WiderFace](http://mmlab.ie.cuhk.edu.hk/projects/WIDERFace/) dataset and put it in `./data/WiderFace`. We have provided the cache files in `./data/cache/widerface` or you can follow [./genetrate_cache_wider.py](./genetrate_cache_wider.py) to cerate them.
+ You should firstly download the [WiderFace](http://mmlab.ie.cuhk.edu.hk/projects/WIDERFace/) dataset and put it in `./data/WiderFace`. We have provided the cache files in `./data/cache/widerface` or you can follow [./genetrate_cache_wider.py](./genetrate_cache_wider.py) to cerate them. The directory structure of `$CSP/data/WiderFace` should be:
+ ```shell
+CSP/data/WiderFace/
+|-- WIDER_test
+|   `-- images
+|       |...
+|-- WIDER_train
+|   `-- images
+|       |...
+|-- WIDER_val
+|   `-- images
+|       |...
+`-- wider_face_split
+ ```
  
 2. Training and Test
 

--- a/keras_csp/Makefile
+++ b/keras_csp/Makefile
@@ -1,0 +1,3 @@
+all:
+	python setup.py build_ext --inplace
+	rm -rf build

--- a/keras_csp/setup.py
+++ b/keras_csp/setup.py
@@ -1,0 +1,142 @@
+# --------------------------------------------------------
+# Fast R-CNN
+# Copyright (c) 2015 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Written by Ross Girshick
+# --------------------------------------------------------
+
+import os
+from os.path import join as pjoin
+from setuptools import setup
+from distutils.extension import Extension
+from Cython.Distutils import build_ext
+import subprocess
+import numpy as np
+
+def find_in_path(name, path):
+    "Find a file in a search path"
+    # Adapted fom
+    # http://code.activestate.com/recipes/52224-find-a-file-given-a-search-path/
+    for dir in path.split(os.pathsep):
+        binpath = pjoin(dir, name)
+        if os.path.exists(binpath):
+            return os.path.abspath(binpath)
+    return None
+
+
+def locate_cuda():
+    """Locate the CUDA environment on the system
+
+    Returns a dict with keys 'home', 'nvcc', 'include', and 'lib64'
+    and values giving the absolute path to each directory.
+
+    Starts by looking for the CUDAHOME env variable. If not found, everything
+    is based on finding 'nvcc' in the PATH.
+    """
+
+    # first check if the CUDAHOME env variable is in use
+    if 'CUDAHOME' in os.environ:
+        home = os.environ['CUDAHOME']
+        nvcc = pjoin(home, 'bin', 'nvcc')
+    else:
+        # otherwise, search the PATH for NVCC
+        default_path = pjoin(os.sep, 'usr', 'local', 'cuda', 'bin')
+        nvcc = find_in_path('nvcc', os.environ['PATH'] + os.pathsep + default_path)
+        if nvcc is None:
+            raise EnvironmentError('The nvcc binary could not be '
+                'located in your $PATH. Either add it to your path, or set $CUDAHOME')
+        home = os.path.dirname(os.path.dirname(nvcc))
+
+    cudaconfig = {'home':home, 'nvcc':nvcc,
+                  'include': pjoin(home, 'include'),
+                  'lib64': pjoin(home, 'lib64')}
+    for k, v in cudaconfig.iteritems():
+        if not os.path.exists(v):
+            raise EnvironmentError('The CUDA %s path could not be located in %s' % (k, v))
+
+    return cudaconfig
+CUDA = locate_cuda()
+
+
+# Obtain the numpy include directory.  This logic works across numpy versions.
+try:
+    numpy_include = np.get_include()
+except AttributeError:
+    numpy_include = np.get_numpy_include()
+
+def customize_compiler_for_nvcc(self):
+    """inject deep into distutils to customize how the dispatch
+    to gcc/nvcc works.
+
+    If you subclass UnixCCompiler, it's not trivial to get your subclass
+    injected in, and still have the right customizations (i.e.
+    distutils.sysconfig.customize_compiler) run on it. So instead of going
+    the OO route, I have this. Note, it's kindof like a wierd functional
+    subclassing going on."""
+
+    # tell the compiler it can processes .cu
+    self.src_extensions.append('.cu')
+
+    # save references to the default compiler_so and _comple methods
+    default_compiler_so = self.compiler_so
+    super = self._compile
+
+    # now redefine the _compile method. This gets executed for each
+    # object but distutils doesn't have the ability to change compilers
+    # based on source extension: we add it.
+    def _compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
+        if os.path.splitext(src)[1] == '.cu':
+            # use the cuda for .cu files
+            self.set_executable('compiler_so', CUDA['nvcc'])
+            # use only a subset of the extra_postargs, which are 1-1 translated
+            # from the extra_compile_args in the Extension class
+            postargs = extra_postargs['nvcc']
+        else:
+            postargs = extra_postargs['gcc']
+
+        super(obj, src, ext, cc_args, postargs, pp_opts)
+        # reset the default compiler_so, which we might have changed for cuda
+        self.compiler_so = default_compiler_so
+
+    # inject our redefined _compile method into the class
+    self._compile = _compile
+
+
+# run the customize_compiler
+class custom_build_ext(build_ext):
+    def build_extensions(self):
+        customize_compiler_for_nvcc(self.compiler)
+        build_ext.build_extensions(self)
+
+
+ext_modules = [
+    Extension(
+        "nms.cpu_nms",
+        ["nms/cpu_nms.pyx"],
+        extra_compile_args={'gcc': ["-Wno-cpp", "-Wno-unused-function"]},
+        include_dirs = [numpy_include]
+    ),
+    Extension('nms.gpu_nms',
+        ['nms/nms_kernel.cu', 'nms/gpu_nms.pyx'],
+        library_dirs=[CUDA['lib64']],
+        libraries=['cudart'],
+        language='c++',
+        runtime_library_dirs=[CUDA['lib64']],
+        # this syntax is specific to this build system
+        # we're only going to use certain compiler args with nvcc and not with
+        # gcc the implementation of this trick is in customize_compiler() below
+        extra_compile_args={'gcc': ["-Wno-unused-function"],
+                            'nvcc': ['-arch=sm_35',
+                                     '--ptxas-options=-v',
+                                     '-c',
+                                     '--compiler-options',
+                                     "'-fPIC'"]},
+        include_dirs = [numpy_include, CUDA['include']]
+    ),
+]
+
+setup(
+    ext_modules=ext_modules,
+    # inject our custom trigger
+    cmdclass={'build_ext': custom_build_ext},
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy==1.12.0
 opencv-python==3.4.1.15
 Pillow==4.0.0
 keras==2.0.6
+h5py==2.10.0

--- a/test_wider_ms.py
+++ b/test_wider_ms.py
@@ -1,6 +1,7 @@
 from __future__ import division
 import os
 import time
+import sys
 import cPickle
 from keras.layers import Input
 from keras.models import Model
@@ -52,8 +53,8 @@ for w_ind in range(382,383):
 	print res_path
 
 	start_time = time.time()
-	for f in range(num_imgs):
-		filepath = val_data[f]['filepath']
+	for idx in range(num_imgs):
+		filepath = val_data[idx]['filepath']
 		event = filepath.split('/')[-2]
 		event_path = os.path.join(res_path, event)
 		if not os.path.exists(event_path):
@@ -160,4 +161,10 @@ for w_ind in range(382,383):
 			for line in dets:
 				f.write('{:.0f} {:.0f} {:.0f} {:.0f} {:.3f}\n'.
 						format(line[0], line[1], line[2] - line[0] + 1, line[3] - line[1] + 1, line[4]))
+
+		# simple progress bar
+		sys.stdout.write('\r')
+		sys.stdout.write('{:5d}/{:5d}: {:s} done.'.format(idx+1, num_imgs, filename))
+		sys.stdout.flush()
+
 	print time.time() - start_time


### PR DESCRIPTION
Changes are:
- Compile nms module
    - Add `Makefile` from https://github.com/rbgirshick/py-faster-rcnn/blob/master/lib/Makefile
    - Add `setup.py` from https://github.com/rbgirshick/py-faster-rcnn/blob/master/lib/setup.py with [line 113-118](https://github.com/rbgirshick/py-faster-rcnn/blob/781a917b378dbfdedb45b6a56189a31982da1b43/lib/setup.py#L113-L118) and [line 142-149](https://github.com/rbgirshick/py-faster-rcnn/blob/781a917b378dbfdedb45b6a56189a31982da1b43/lib/setup.py#L142-L149) removed
    - Add instructions in `README.md` to compile nms module
- Add h5py to python requirements
- Add widerface directory structure tree in `README.md` to help placing widerface dataset correctly
- Add a simple progress bar in `test_wider_ms.py`